### PR TITLE
oya render enhancements

### DIFF
--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -24,3 +24,11 @@ func installDir() (string, error) {
 
 	return filepath.Join(homeDir, ".oya", "packs"), nil
 }
+
+func lookupOyaScope() (string, bool) {
+	return os.LookupEnv("OYA_SCOPE")
+}
+
+func setOyaScope(scope string) error {
+	return os.Setenv("OYA_SCOPE", scope)
+}

--- a/cmd/internal/render.go
+++ b/cmd/internal/render.go
@@ -17,7 +17,7 @@ func (err ErrNoAlias) Error() string {
 	return fmt.Sprintf("Unknown import alias %q in %v", err.Alias, err.OyafilePath)
 }
 
-func Render(oyafilePath, templatePath, outputPath, alias string, stdout, stderr io.Writer) error {
+func Render(oyafilePath, templatePath, outputPath string, autoScope bool, alias string, stdout, stderr io.Writer) error {
 	installDir, err := installDir()
 	if err != nil {
 		return err
@@ -44,6 +44,9 @@ func Render(oyafilePath, templatePath, outputPath, alias string, stdout, stderr 
 
 	var values template.Scope
 	if found {
+		if autoScope && alias == "" {
+			alias, _ = lookupOyaScope()
+		}
 		if alias != "" {
 			av, ok := o.Values[alias]
 			if !ok {

--- a/cmd/internal/render.go
+++ b/cmd/internal/render.go
@@ -3,9 +3,11 @@ package internal
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/bilus/oya/pkg/project"
 	"github.com/bilus/oya/pkg/template"
+	"github.com/pkg/errors"
 )
 
 type ErrNoScope struct {
@@ -14,7 +16,7 @@ type ErrNoScope struct {
 }
 
 func (err ErrNoScope) Error() string {
-	return fmt.Sprintf("Scope %q not found in %v", err.Scope, err.OyafilePath)
+	return fmt.Sprintf("Scope not found in %v: %q missing or cannot be used as a scope", err.OyafilePath, err.Scope)
 }
 
 func Render(oyafilePath, templatePath, outputPath string, autoScope bool, scopeSelector string, stdout, stderr io.Writer) error {
@@ -47,20 +49,53 @@ func Render(oyafilePath, templatePath, outputPath string, autoScope bool, scopeS
 		if autoScope && scopeSelector == "" {
 			scopeSelector, _ = lookupOyaScope()
 		}
+		// BUG(bilus): Breaking encapsulation here (see task.Name#Split)
 		if scopeSelector != "" {
-			av, ok := o.Values[scopeSelector]
-			if !ok {
-				return ErrNoScope{Scope: scopeSelector, OyafilePath: oyafilePath}
-			}
-			selectedScope, ok := av.(template.Scope)
-			if !ok {
-				return ErrNoScope{Scope: scopeSelector, OyafilePath: oyafilePath}
-			}
-			values = selectedScope
+			scopeSelectorParts := strings.Split(scopeSelector, ".")
+			values, err = resolveScope(scopeSelectorParts, o.Values)
 		} else {
-			values = o.Values
+			values, err = resolveScope(nil, o.Values)
+		}
+		if err != nil {
+			// BUG(bilus): Ignoring err.
+			return ErrNoScope{Scope: scopeSelector, OyafilePath: oyafilePath}
 		}
 	}
 
 	return template.RenderAll(templatePath, outputPath, values)
+}
+
+func resolveScope(scopeSelector []string, scope template.Scope) (template.Scope, error) {
+	if len(scopeSelector) == 0 {
+		return scope, nil
+	}
+
+	scopeName := scopeSelector[0]
+	potentialScope, ok := scope[scopeName]
+	if !ok {
+		return nil, errors.Errorf("Missing key %q", scopeName)
+	}
+	subScope, ok := parseScope(potentialScope)
+	if !ok {
+		return nil, errors.Errorf("Unsupported scope under %q", scopeName)
+	}
+	return resolveScope(scopeSelector[1:], subScope)
+}
+
+func parseScope(potentialScope interface{}) (template.Scope, bool) {
+	if selectedScope, ok := potentialScope.(template.Scope); ok {
+		return selectedScope, true
+	}
+	if aMap, ok := potentialScope.(map[interface{}]interface{}); ok {
+		scope := make(template.Scope)
+		for k, v := range aMap {
+			name, ok := k.(string)
+			if !ok {
+				return nil, false
+			}
+			scope[name] = v
+		}
+		return scope, true
+	}
+	return nil, false
 }

--- a/cmd/internal/render.go
+++ b/cmd/internal/render.go
@@ -8,16 +8,16 @@ import (
 	"github.com/bilus/oya/pkg/template"
 )
 
-type ErrNoAlias struct {
-	Alias       string
+type ErrNoScope struct {
+	Scope       string
 	OyafilePath string
 }
 
-func (err ErrNoAlias) Error() string {
-	return fmt.Sprintf("Unknown import alias %q in %v", err.Alias, err.OyafilePath)
+func (err ErrNoScope) Error() string {
+	return fmt.Sprintf("Scope %q not found in %v", err.Scope, err.OyafilePath)
 }
 
-func Render(oyafilePath, templatePath, outputPath string, autoScope bool, alias string, stdout, stderr io.Writer) error {
+func Render(oyafilePath, templatePath, outputPath string, autoScope bool, scopeSelector string, stdout, stderr io.Writer) error {
 	installDir, err := installDir()
 	if err != nil {
 		return err
@@ -44,19 +44,19 @@ func Render(oyafilePath, templatePath, outputPath string, autoScope bool, alias 
 
 	var values template.Scope
 	if found {
-		if autoScope && alias == "" {
-			alias, _ = lookupOyaScope()
+		if autoScope && scopeSelector == "" {
+			scopeSelector, _ = lookupOyaScope()
 		}
-		if alias != "" {
-			av, ok := o.Values[alias]
+		if scopeSelector != "" {
+			av, ok := o.Values[scopeSelector]
 			if !ok {
-				return ErrNoAlias{Alias: alias, OyafilePath: oyafilePath}
+				return ErrNoScope{Scope: scopeSelector, OyafilePath: oyafilePath}
 			}
-			aliasScope, ok := av.(template.Scope)
+			selectedScope, ok := av.(template.Scope)
 			if !ok {
-				return ErrNoAlias{Alias: alias, OyafilePath: oyafilePath}
+				return ErrNoScope{Scope: scopeSelector, OyafilePath: oyafilePath}
 			}
-			values = aliasScope
+			values = selectedScope
 		} else {
 			values = o.Values
 		}

--- a/cmd/internal/run.go
+++ b/cmd/internal/run.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bilus/oya/pkg/template"
 )
 
-func Run(workDir, taskName string, positionalArgs []string, flags map[string]string, stdout, stderr io.Writer) error {
+func Run(workDir, taskName string, recurse, changeset bool, positionalArgs []string, flags map[string]string, stdout, stderr io.Writer) error {
 	installDir, err := installDir()
 	if err != nil {
 		return err
@@ -30,13 +30,13 @@ func Run(workDir, taskName string, positionalArgs []string, flags map[string]str
 	tn := task.Name(taskName)
 
 	alias, _ := tn.Split()
-	oldScope, _ := lookupOyaScope()
+	oldOyaScope, _ := lookupOyaScope()
 	if err := setOyaScope(alias.String()); err != nil {
 		return err
 	}
-	defer setOyaScope(oldScope)
+	defer setOyaScope(oldOyaScope) // Mostly useful in tests, child processes naturally implement stacks.
 
-	return p.Run(workDir, tn, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
+	return p.Run(workDir, tn, recurse, changeset, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
 }
 
 func toScope(positionalArgs []string, flags map[string]string) template.Scope {

--- a/cmd/internal/run.go
+++ b/cmd/internal/run.go
@@ -27,7 +27,14 @@ func Run(workDir, taskName string, positionalArgs []string, flags map[string]str
 	if err != nil {
 		return err
 	}
-	return p.Run(workDir, task.Name(taskName), toScope(positionalArgs, flags).Merge(values), stdout, stderr)
+	tn := task.Name(taskName)
+
+	alias, _ := tn.Split()
+	if err := setOyaScope(alias.String()); err != nil {
+		return err
+	}
+
+	return p.Run(workDir, tn, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
 }
 
 func toScope(positionalArgs []string, flags map[string]string) template.Scope {

--- a/cmd/internal/run.go
+++ b/cmd/internal/run.go
@@ -30,9 +30,11 @@ func Run(workDir, taskName string, positionalArgs []string, flags map[string]str
 	tn := task.Name(taskName)
 
 	alias, _ := tn.Split()
+	oldScope, _ := lookupOyaScope()
 	if err := setOyaScope(alias.String()); err != nil {
 		return err
 	}
+	defer setOyaScope(oldScope)
 
 	return p.Run(workDir, tn, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
 }

--- a/cmd/internal/tasks.go
+++ b/cmd/internal/tasks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bilus/oya/pkg/task"
 )
 
-func Tasks(workDir string, stdout, stderr io.Writer) error {
+func Tasks(workDir string, recurse, changeset bool, stdout, stderr io.Writer) error {
 
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 
@@ -26,7 +26,7 @@ func Tasks(workDir string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	oyafiles, err := p.Changeset(workDir)
+	oyafiles, err := p.RunTargets(workDir, recurse, changeset)
 	if err != nil {
 		return err
 	}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -62,5 +62,5 @@ func init() {
 	renderCmd.Flags().StringP("file", "f", "./Oyafile", "Path to Oyafile to read")
 	renderCmd.Flags().StringP("output-dir", "o", ".", "Specify the output DIRECTORY")
 	renderCmd.Flags().StringP("scope", "s", "", "Render template within the specified value scope")
-	renderCmd.Flags().BoolP("auto-scope", "a", false, "Automatically detect value scope when running in imported tasks")
+	renderCmd.Flags().BoolP("auto-scope", "a", true, "When running in an imported pack's task, use the pack's scope, unless --")
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/bilus/oya/cmd/internal"
@@ -25,7 +24,7 @@ import (
 // renderCmd represents the render command
 var renderCmd = &cobra.Command{
 	Use:   "render TEMPLATE",
-	Short: "Render a template using values from an Oyafile",
+	Short: "Render a template FILE or DIRECTORY using values from an Oyafile",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		oyafilePath, err := cmd.Flags().GetString("file")
@@ -33,7 +32,12 @@ var renderCmd = &cobra.Command{
 			return err
 		}
 		templatePath := args[0]
-		outputPath, err := os.Getwd()
+		outputPath, err := cmd.Flags().GetString("output-dir")
+		if err != nil {
+			return err
+		}
+		// This will turn "." or empty output path into full path relative to pwd.
+		fullOutputPath, err := filepath.Abs(outputPath)
 		if err != nil {
 			return err
 		}
@@ -49,13 +53,14 @@ var renderCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return internal.Render(fullOyafilePath, templatePath, outputPath, autoScope, scopeSelector, cmd.OutOrStdout(), cmd.OutOrStderr())
+		return internal.Render(fullOyafilePath, templatePath, fullOutputPath, autoScope, scopeSelector, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(renderCmd)
-	renderCmd.Flags().StringP("file", "f", "Oyafile", "Read FILE as Oyafile")
+	renderCmd.Flags().StringP("file", "f", "./Oyafile", "Path to Oyafile to read")
+	renderCmd.Flags().StringP("output-dir", "o", ".", "Specify the output DIRECTORY")
 	renderCmd.Flags().StringP("scope", "s", "", "Render template within the specified value scope")
 	renderCmd.Flags().BoolP("auto-scope", "a", false, "Automatically detect value scope when running in imported tasks")
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -45,17 +45,17 @@ var renderCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		alias, err := cmd.Flags().GetString("alias")
+		scopeSelector, err := cmd.Flags().GetString("scope")
 		if err != nil {
 			return err
 		}
-		return internal.Render(fullOyafilePath, templatePath, outputPath, autoScope, alias, cmd.OutOrStdout(), cmd.OutOrStderr())
+		return internal.Render(fullOyafilePath, templatePath, outputPath, autoScope, scopeSelector, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(renderCmd)
 	renderCmd.Flags().StringP("file", "f", "Oyafile", "Read FILE as Oyafile")
-	renderCmd.Flags().StringP("alias", "a", "", "Render template in alias context")
-	renderCmd.Flags().BoolP("auto-scope", "s", false, "Automatically detect scope when running in imported tasks")
+	renderCmd.Flags().StringP("scope", "s", "", "Render template within the specified value scope")
+	renderCmd.Flags().BoolP("auto-scope", "a", false, "Automatically detect value scope when running in imported tasks")
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -41,11 +41,15 @@ var renderCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		autoScope, err := cmd.Flags().GetBool("auto-scope")
+		if err != nil {
+			return err
+		}
 		alias, err := cmd.Flags().GetString("alias")
 		if err != nil {
 			return err
 		}
-		return internal.Render(fullOyafilePath, templatePath, outputPath, alias, cmd.OutOrStdout(), cmd.OutOrStderr())
+		return internal.Render(fullOyafilePath, templatePath, outputPath, autoScope, alias, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 }
 
@@ -53,4 +57,5 @@ func init() {
 	rootCmd.AddCommand(renderCmd)
 	renderCmd.Flags().StringP("file", "f", "Oyafile", "Read FILE as Oyafile")
 	renderCmd.Flags().StringP("alias", "a", "", "Render template in alias context")
+	renderCmd.Flags().BoolP("auto-scope", "s", false, "Automatically detect scope when running in imported tasks")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,6 @@ to quickly create a Cobra application.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -64,6 +65,21 @@ func ExecuteE() error {
 // SetOutput overrides cobra output (for testing).
 func SetOutput(out io.Writer) {
 	rootCmd.SetOutput(out)
+}
+
+// Reset all flags for all commands to their default values (testing).
+func ResetFlags() {
+	resetFlagsRecurse(rootCmd)
+}
+
+func resetFlagsRecurse(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(
+		func(flag *pflag.Flag) {
+			flag.Value.Set(flag.DefValue)
+		})
+	for _, child := range cmd.Commands() {
+		resetFlagsRecurse(child)
+	}
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,11 +72,7 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.oya.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.oya.yaml)")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -36,11 +36,21 @@ var tasksCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return internal.Tasks(cwd, cmd.OutOrStdout(), cmd.OutOrStderr())
+		recurse, err := cmd.Flags().GetBool("recurse")
+		if err != nil {
+			return err
+		}
+		changeset, err := cmd.Flags().GetBool("changeset")
+		if err != nil {
+			return err
+		}
+		return internal.Tasks(cwd, recurse, changeset, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 	Args: cobra.NoArgs,
 }
 
 func init() {
 	rootCmd.AddCommand(tasksCmd)
+	tasksCmd.Flags().BoolP("recurse", "r", false, "Recursively process Oyafiles")
+	tasksCmd.Flags().BoolP("changeset", "c", false, "Use the Changeset: directives")
 }

--- a/features/builtins.feature
+++ b/features/builtins.feature
@@ -92,7 +92,7 @@ Scenario: Access Oyafile base directory
     all: |
       echo $BasePath
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout text matching
   """
@@ -150,7 +150,7 @@ Scenario: Access Oyafile Project name in nested dir
     all: |
       echo $Project
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout text matching
   """

--- a/features/changeset.feature
+++ b/features/changeset.feature
@@ -1,0 +1,90 @@
+Feature: Changesets
+
+Background:
+   Given I'm in project dir
+
+Scenario: No changes
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo ""
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo ""
+    all: |
+      echo "Project1"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  """
+
+Scenario: Child marks itself as changed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo ""
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo "+."
+    all: |
+      echo "Root"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Root
+
+  """
+
+Scenario: Child marks parent as changed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo ""
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo "+../"
+    all: |
+      echo "Root"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Root
+
+  """
+
+Scenario: Parent marks child as changed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo "+project1/"
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo ""
+    all: |
+      echo "Project1"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Project1
+
+  """

--- a/features/get.feature
+++ b/features/get.feature
@@ -46,7 +46,7 @@ Scenario: Get two versions of the same pack
       fixtures: github.com/tooploox/oya-fixtures
     """
   When I'm in the ./project1 dir
-  And I run "oya run fixtures.version"
+  And I run "oya run --recurse fixtures.version"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/ignore.feature
+++ b/features/ignore.feature
@@ -13,7 +13,7 @@ Scenario: Empty .oyaignore
     """
     all: echo "subdir"
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -34,7 +34,7 @@ Scenario: Ignore file
     """
     all: echo "subdir"
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -58,7 +58,7 @@ Scenario: Wildcard ignore
     """
     all: echo "subdir/foo"
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/imports.feature
+++ b/features/imports.feature
@@ -136,7 +136,7 @@ Scenario: Access current project values
       echo $p1.foo
       echo $foo
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -227,10 +227,37 @@ Scenario: Import tasks in a subdir Oyafile
       echo "all"
     """
   And I'm in the ./subdir dir
-  When I run "oya run foo.all"
+  When I run "oya run --recurse foo.all"
   Then the command succeeds
   And the command outputs to stdout
   """
   all
+
+  """
+
+Scenario: Import tasks from a subdirectory
+  Given file ./Oyafile containing
+    """
+    Project: main
+    """
+  And file ./project1/Oyafile containing
+    """
+    Values:
+      foo: project1
+
+    echo: |
+      echo "project1"
+    """
+  And file ./project2/Oyafile containing
+    """
+    Import:
+      project1: /project1
+    """
+  And I'm in the ./project2 dir
+  When I run "oya run project1.echo"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  project1
 
   """

--- a/features/render.feature
+++ b/features/render.feature
@@ -113,7 +113,7 @@ Scenario: Render templated values in alias scope
     """
     $fruit
     """
-  When I run "oya render -a foo ./templates/file.txt"
+  When I run "oya render --scope foo ./templates/file.txt"
   Then the command succeeds
   And file ./file.txt contains
   """
@@ -143,7 +143,7 @@ Scenario: Render templated values in alias scope can be overridden
     """
     $fruit
     """
-  When I run "oya render -a foo ./templates/file.txt"
+  When I run "oya render --scope foo ./templates/file.txt"
   Then the command succeeds
   And file ./file.txt contains
   """

--- a/features/render.feature
+++ b/features/render.feature
@@ -286,3 +286,50 @@ Scenario: Rendering values in specified nested scope
   """
   orange
   """
+
+Scenario: Rendering one file to an output dir
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Values:
+      fruit: orange
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya render --output-dir ./foobar ./templates/file.txt"
+  Then the command succeeds
+  And file ./foobar/file.txt contains
+  """
+  orange
+  """
+
+Scenario: Rendering a dir to an output dir
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Values:
+      culprit: Eve
+      weapon: apple
+    """
+  And file ./templates/file1.txt containing
+    """
+    $weapon
+    """
+  And file ./templates/file2.txt containing
+    """
+    $culprit
+    """
+  When I run "oya render --output-dir ./foobar ./templates/"
+  Then the command succeeds
+  And file ./foobar/file1.txt contains
+  """
+  apple
+  """
+  And file ./foobar/file2.txt contains
+  """
+  Eve
+  """

--- a/features/render.feature
+++ b/features/render.feature
@@ -93,7 +93,7 @@ Scenario: Render templated paths
   yyy
   """
 
-Scenario: Render templated values in alias scope
+Scenario: Rendering values in specified scope pointing to imported pack
   Given file ./Oyafile containing
     """
     Project: project
@@ -120,7 +120,7 @@ Scenario: Render templated values in alias scope
   orange
   """
 
-Scenario: Render templated values in alias scope can be overridden
+Scenario: Rendered values in specified scope can be overridden
   Given file ./Oyafile containing
     """
     Project: project
@@ -183,7 +183,7 @@ Scenario: Imported tasks render using target Oyafile scope
   apple
   """
 
-Scenario: Alias scope can we detected in imported tasks
+Scenario: Scope can we detected in imported tasks
   Given file ./Oyafile containing
     """
     Project: project
@@ -213,7 +213,7 @@ Scenario: Alias scope can we detected in imported tasks
   orange
   """
 
-Scenario: Render templated values in alias scope can be overridden when auto-detecting scope
+Scenario: Values in auto-detected scope can be overridden
   Given file ./Oyafile containing
     """
     Project: project
@@ -244,4 +244,45 @@ Scenario: Render templated values in alias scope can be overridden when auto-det
   And file ./file.txt contains
   """
   banana
+  """
+
+Scenario: Rendering values in specified scope
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Values:
+      fruits:
+        fruit: orange
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya render --scope fruits ./templates/file.txt"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  orange
+  """
+
+Scenario: Rendering values in specified nested scope
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Values:
+      plants:
+        fruits:
+          fruit: orange
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya render --scope plants.fruits ./templates/file.txt"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  orange
   """

--- a/features/render.feature
+++ b/features/render.feature
@@ -150,7 +150,7 @@ Scenario: Rendered values in specified scope can be overridden
   banana
   """
 
-Scenario: Imported tasks render using target Oyafile scope
+Scenario: Imported tasks render using their own Oyafile scope by default
   Given file ./Oyafile containing
     """
     Project: project
@@ -160,9 +160,6 @@ Scenario: Imported tasks render using target Oyafile scope
 
     Import:
       foo: github.com/test/foo
-
-    Values:
-      fruit: apple
     """
   And file ./.oya/packs/github.com/test/foo@v0.0.1/Oyafile containing
     """
@@ -180,40 +177,10 @@ Scenario: Imported tasks render using target Oyafile scope
   Then the command succeeds
   And file ./file.txt contains
   """
-  apple
-  """
-
-Scenario: Scope can we detected in imported tasks
-  Given file ./Oyafile containing
-    """
-    Project: project
-
-    Require:
-      github.com/test/foo: v0.0.1
-
-    Import:
-      foo: github.com/test/foo
-    """
-  And file ./.oya/packs/github.com/test/foo@v0.0.1/Oyafile containing
-    """
-    Values:
-      fruit: orange
-
-    render:
-      $OyaCmd render --auto-scope ./templates/file.txt
-    """
-  And file ./templates/file.txt containing
-    """
-    $fruit
-    """
-  When I run "oya run foo.render"
-  Then the command succeeds
-  And file ./file.txt contains
-  """
   orange
   """
 
-Scenario: Values in auto-detected scope can be overridden
+Scenario: Values in imported pack scope can be overridden
   Given file ./Oyafile containing
     """
     Project: project
@@ -233,7 +200,7 @@ Scenario: Values in auto-detected scope can be overridden
       fruit: orange
 
     render:
-      $OyaCmd render --auto-scope ./templates/file.txt
+      $OyaCmd render ./templates/file.txt
     """
   And file ./templates/file.txt containing
     """
@@ -245,6 +212,39 @@ Scenario: Values in auto-detected scope can be overridden
   """
   banana
   """
+Scenario: Scope of the importing Oyafile can be optionally used
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Require:
+      github.com/test/foo: v0.0.1
+
+    Import:
+      foo: github.com/test/foo
+
+    Values:
+      fruit: apple
+    """
+  And file ./.oya/packs/github.com/test/foo@v0.0.1/Oyafile containing
+    """
+    Values:
+      fruit: orange
+
+    render:
+      $OyaCmd render --auto-scope=false ./templates/file.txt
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya run foo.render"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  apple
+  """
+
 
 Scenario: Rendering values in specified scope
   Given file ./Oyafile containing
@@ -266,6 +266,7 @@ Scenario: Rendering values in specified scope
   orange
   """
 
+@xx
 Scenario: Rendering values in specified nested scope
   Given file ./Oyafile containing
     """
@@ -287,6 +288,7 @@ Scenario: Rendering values in specified nested scope
   orange
   """
 
+@xx
 Scenario: Rendering one file to an output dir
   Given file ./Oyafile containing
     """

--- a/features/render.feature
+++ b/features/render.feature
@@ -14,6 +14,24 @@ Scenario: Render a template
     """
     $foo
     """
+  When I run "oya render ./templates/file.txt"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  xxx
+  """
+
+Scenario: Render a template explicitly pointing to the Oyafile
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Values:
+      foo: xxx
+    """
+  Given file ./templates/file.txt containing
+    """
+    $foo
+    """
   When I run "oya render -f ./Oyafile ./templates/file.txt"
   Then the command succeeds
   And file ./file.txt contains
@@ -37,7 +55,7 @@ Scenario: Render a template directory
     """
     $bar
     """
-  When I run "oya render -f ./Oyafile ./templates/"
+  When I run "oya render ./templates/"
   Then the command succeeds
   And file ./file.txt contains
   """
@@ -64,7 +82,7 @@ Scenario: Render templated paths
     """
     $bar
     """
-  When I run "oya render -f ./Oyafile ./templates/"
+  When I run "oya render ./templates/"
   Then the command succeeds
   And file ./xxx.txt contains
   """
@@ -95,7 +113,7 @@ Scenario: Render templated values in alias scope
     """
     $fruit
     """
-  When I run "oya render -f ./Oyafile -a foo ./templates/file.txt"
+  When I run "oya render -a foo ./templates/file.txt"
   Then the command succeeds
   And file ./file.txt contains
   """
@@ -125,7 +143,7 @@ Scenario: Render templated values in alias scope can be overridden
     """
     $fruit
     """
-  When I run "oya render -f ./Oyafile -a foo ./templates/file.txt"
+  When I run "oya render -a foo ./templates/file.txt"
   Then the command succeeds
   And file ./file.txt contains
   """
@@ -152,7 +170,7 @@ Scenario: Imported tasks render using target Oyafile scope
       fruit: orange
 
     render:
-      $OyaCmd render -f ./Oyafile ./templates/file.txt
+      $OyaCmd render ./templates/file.txt
     """
   And file ./templates/file.txt containing
     """
@@ -182,7 +200,7 @@ Scenario: Alias scope can we detected in imported tasks
       fruit: orange
 
     render:
-      $OyaCmd render --auto-scope -f ./Oyafile ./templates/file.txt
+      $OyaCmd render --auto-scope ./templates/file.txt
     """
   And file ./templates/file.txt containing
     """
@@ -215,7 +233,7 @@ Scenario: Render templated values in alias scope can be overridden when auto-det
       fruit: orange
 
     render:
-      $OyaCmd render --auto-scope -f ./Oyafile ./templates/file.txt
+      $OyaCmd render --auto-scope ./templates/file.txt
     """
   And file ./templates/file.txt containing
     """

--- a/features/render.feature
+++ b/features/render.feature
@@ -131,3 +131,99 @@ Scenario: Render templated values in alias scope can be overridden
   """
   banana
   """
+
+Scenario: Imported tasks render using target Oyafile scope
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Require:
+      github.com/test/foo: v0.0.1
+
+    Import:
+      foo: github.com/test/foo
+
+    Values:
+      fruit: apple
+    """
+  And file ./.oya/packs/github.com/test/foo@v0.0.1/Oyafile containing
+    """
+    Values:
+      fruit: orange
+
+    render:
+      $OyaCmd render -f ./Oyafile ./templates/file.txt
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya run foo.render"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  apple
+  """
+
+Scenario: Alias scope can we detected in imported tasks
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Require:
+      github.com/test/foo: v0.0.1
+
+    Import:
+      foo: github.com/test/foo
+    """
+  And file ./.oya/packs/github.com/test/foo@v0.0.1/Oyafile containing
+    """
+    Values:
+      fruit: orange
+
+    render:
+      $OyaCmd render --auto-scope -f ./Oyafile ./templates/file.txt
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya run foo.render"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  orange
+  """
+
+Scenario: Render templated values in alias scope can be overridden when auto-detecting scope
+  Given file ./Oyafile containing
+    """
+    Project: project
+
+    Require:
+      github.com/test/foo: v0.0.1
+
+    Import:
+      foo: github.com/test/foo
+
+    Values:
+      foo.fruit: banana
+    """
+  And file ./.oya/packs/github.com/test/foo@v0.0.1/Oyafile containing
+    """
+    Values:
+      fruit: orange
+
+    render:
+      $OyaCmd render --auto-scope -f ./Oyafile ./templates/file.txt
+    """
+  And file ./templates/file.txt containing
+    """
+    $fruit
+    """
+  When I run "oya run foo.render"
+  Then the command succeeds
+  And file ./file.txt contains
+  """
+  banana
+  """

--- a/features/require.feature
+++ b/features/require.feature
@@ -311,7 +311,7 @@ Scenario: Indirect requirements are downloaded
     """
   When I run "oya run foo"
   Then the command succeeds
-  Then file ./.oya/packs/github.com/tooploox/oya-fixtures/pack3@v1.0.0/Oyafile contains
+  And file ./.oya/packs/github.com/tooploox/oya-fixtures/pack3@v1.0.0/Oyafile contains
     """
     Project: github.com/tooploox/oya-fixtures/pack3
 
@@ -334,7 +334,7 @@ Scenario: Indirectly required higher version
     """
     Project: project
     Require:
-      github.com/tooploox/oya-fixtures/pack3: v1.0.0
+      github.com/tooploox/oya-fixtures/pack3: v1.0.0  # Requires pack1@v1.1.1
       github.com/tooploox/oya-fixtures/pack1: v1.0.0
 
     Import:

--- a/features/run.feature
+++ b/features/run.feature
@@ -23,7 +23,7 @@ Scenario: Successfully run task
   """
   And file ./OK exists
 
-Scenario: Nested Oyafiles
+Scenario: Nested Oyafiles are not processed recursively by default
   Given file ./Oyafile containing
     """
     Project: project
@@ -48,6 +48,37 @@ Scenario: Nested Oyafiles
   And the command outputs to stdout
   """
   Root
+
+  """
+  And file ./Root exists
+  And file ./project1/Project1 does not exist
+  And file ./project2/Project2 does not exist
+
+Scenario: Nested Oyafiles can be processed recursively
+  Given file ./Oyafile containing
+    """
+    Project: project
+    all: |
+      touch Root
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    all: |
+      touch Project1
+      echo "Project1"
+    """
+  And file ./project2/Oyafile containing
+    """
+    all: |
+      touch Project2
+      echo "Project2"
+    """
+  When I run "oya run --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Root
   Project1
   Project2
 
@@ -55,92 +86,6 @@ Scenario: Nested Oyafiles
   And file ./Root exists
   And file ./project1/Project1 exists
   And file ./project2/Project2 exists
-
-Scenario: No changes
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo ""
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo ""
-    all: |
-      echo "Project1"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  """
-
-Scenario: Child marks itself as changed
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo ""
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo "+."
-    all: |
-      echo "Root"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  Root
-
-  """
-
-Scenario: Child marks parent as changed
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo ""
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo "+../"
-    all: |
-      echo "Root"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  Root
-
-  """
-
-Scenario: Parent marks child as changed
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo "+project1/"
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo ""
-    all: |
-      echo "Project1"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  Project1
-
-  """
 
 Scenario: No Oyafile
   Given file ./NotOyafile containing
@@ -222,7 +167,7 @@ Scenario: Ignore errors in projects inside current project
 
   """
 
-Scenario: Running in subdir
+Scenario: Running recursively
   Given file ./Oyafile containing
     """
     Project: project
@@ -243,7 +188,7 @@ Scenario: Running in subdir
       echo "Project2"
     """
   And I'm in the ./project1 dir
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -253,3 +198,56 @@ Scenario: Running in subdir
   And file ././Root does not exist
   And file ./Project1 exists
   And file ./../project2/Project2 does not exist
+
+Scenario: Running recursively
+  Given file ./Oyafile containing
+    """
+    Project: project
+    all: |
+      touch Root
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    all: |
+      touch Project1
+      echo "Project1"
+    """
+  And file ./project2/Oyafile containing
+    """
+    all: |
+      touch Project2
+      echo "Project2"
+    """
+  And I'm in the ./project1 dir
+  When I run "oya run --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Project1
+
+  """
+  And file ././Root does not exist
+  And file ./Project1 exists
+  And file ./../project2/Project2 does not exist
+
+Scenario: Running in a subdirectory
+  Given file ./Oyafile containing
+    """
+    Project: project
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    all: |
+      echo "Project1"
+    """
+  And I'm in the ./project1 dir
+  When I run "oya run all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Project1
+
+  """

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -36,7 +36,7 @@ Scenario: Show only user-defined
 
   """
 
-Scenario: Subdirectories
+Scenario: Subdirectories are not recursed by default
   Given file ./Oyafile containing
     """
     Project: project
@@ -49,6 +49,27 @@ Scenario: Subdirectories
       echo "Done"
     """
   When I run "oya tasks"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  # in ./Oyafile
+  oya run build
+
+  """
+
+Scenario: Subdirectories can be recursed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    build: |
+      echo "Done"
+    """
+  And file ./subdir1/Oyafile containing
+    """
+    build: |
+      echo "Done"
+    """
+  When I run "oya tasks --recurse"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -98,7 +119,7 @@ Scenario: Doc strings are properly aligned
     foo: |
       echo "Done"
     """
-  When I run "oya tasks"
+  When I run "oya tasks --recurse"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -131,7 +152,7 @@ Scenario: Parent dir tasks are not listed
       echo "Done"
     """
   And I'm in the ./subdir1 dir
-  When I run "oya tasks"
+  When I run "oya tasks --recurse"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/oya_test.go
+++ b/oya_test.go
@@ -129,6 +129,7 @@ func (c *SuiteContext) fileDoesNotExist(path string) error {
 func (c *SuiteContext) execute(command string) error {
 	c.stdout.Reset()
 	c.stderr.Reset()
+	cmd.ResetFlags()
 
 	oldArgs := os.Args
 	os.Args = strings.Fields(command)

--- a/pkg/oyafile/builtins.go
+++ b/pkg/oyafile/builtins.go
@@ -6,7 +6,6 @@ import (
 	"unicode"
 
 	"github.com/Masterminds/sprig"
-	"github.com/bilus/oya/pkg/raw"
 	"github.com/bilus/oya/pkg/task"
 	"github.com/bilus/oya/pkg/template"
 )
@@ -69,6 +68,6 @@ func (o *Oyafile) bindTasks(taskName task.Name, t task.Task, stdout, stderr io.W
 func (o *Oyafile) bindRender(taskName task.Name, stdout, stderr io.Writer) (func(string) string, error) {
 	alias, _ := taskName.Split()
 	return func(templatePath string) string {
-		return fmt.Sprintf("%s render -f ./%s -a %q %s\n", o.OyaCmd, raw.DefaultName, alias, templatePath)
+		return fmt.Sprintf("%s render -a %q %s\n", o.OyaCmd, alias, templatePath)
 	}, nil
 }

--- a/pkg/oyafile/builtins.go
+++ b/pkg/oyafile/builtins.go
@@ -21,6 +21,7 @@ func (o *Oyafile) addBuiltIns() error {
 func (o *Oyafile) defaultValues() template.Scope {
 	scope := template.Scope{
 		"BasePath": o.Dir,
+		"OyaCmd":   o.OyaCmd,
 	}
 
 	// Import sprig functions (http://masterminds.github.io/sprig/).

--- a/pkg/oyafile/builtins.go
+++ b/pkg/oyafile/builtins.go
@@ -68,6 +68,6 @@ func (o *Oyafile) bindTasks(taskName task.Name, t task.Task, stdout, stderr io.W
 func (o *Oyafile) bindRender(taskName task.Name, stdout, stderr io.Writer) (func(string) string, error) {
 	alias, _ := taskName.Split()
 	return func(templatePath string) string {
-		return fmt.Sprintf("%s render -a %q %s\n", o.OyaCmd, alias, templatePath)
+		return fmt.Sprintf("%s render --scope %q %s\n", o.OyaCmd, alias, templatePath)
 	}, nil
 }

--- a/pkg/project/packs.go
+++ b/pkg/project/packs.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p *Project) Require(pack pack.Pack) error {
-	raw, err := p.rootRawOyafile()
+	raw, err := p.rawOyafileIn(p.RootDir)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (p *Project) Deps() (Deps, error) {
 		return p.dependencies, nil
 	}
 
-	o, err := p.rootOyafile()
+	o, err := p.oyafileIn(p.RootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -49,7 +49,15 @@ func TestProject_Run_NoTask(t *testing.T) {
 	installDir := "" // Unused
 	project, err := project.Detect(workDir, installDir)
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
-	err = project.Run(workDir, "noSuchTask", noScope, ioutil.Discard, ioutil.Discard)
+	err = project.Run(workDir, "noSuchTask", false, false, noScope, ioutil.Discard, ioutil.Discard)
+	tu.AssertErr(t, err, "Expected error when trying to run without matching task")
+}
+func TestProject_Run_NoTaskRecurse(t *testing.T) {
+	workDir := "./fixtures/project"
+	installDir := "" // Unused
+	project, err := project.Detect(workDir, installDir)
+	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
+	err = project.Run(workDir, "noSuchTask", true, false, noScope, ioutil.Discard, ioutil.Discard)
 	tu.AssertErr(t, err, "Expected error when trying to run without matching task")
 }
 
@@ -60,7 +68,20 @@ func TestProject_Run_NoChanges(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", noScope, stdout, stderr)
+	err = project.Run(workDir, "build", false, true, noScope, stdout, stderr)
+	tu.AssertNoErr(t, err, "Expected no error running with empty changeset")
+	tu.AssertEqual(t, 0, len(stdout.String()))
+	tu.AssertEqual(t, 0, len(stderr.String()))
+}
+
+func TestProject_Run_NoChangesRecurse(t *testing.T) {
+	workDir := "./fixtures/empty_changeset_project"
+	installDir := "" // Unused
+	project, err := project.Detect(workDir, installDir)
+	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err = project.Run(workDir, "build", true, true, noScope, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running with empty changeset")
 	tu.AssertEqual(t, 0, len(stdout.String()))
 	tu.AssertEqual(t, 0, len(stderr.String()))
@@ -73,7 +94,19 @@ func TestProject_Run_WithChanges(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
+	err = project.Run(workDir, "build", false, true, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
+	tu.AssertNoErr(t, err, "Expected no error running non-empty changeset")
+	tu.AssertEqual(t, "build run", stdout.String())
+}
+
+func TestProject_Run_WithChangesRecurse(t *testing.T) {
+	workDir := "./fixtures/project"
+	installDir := "" // Unused
+	project, err := project.Detect(workDir, installDir)
+	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err = project.Run(workDir, "build", true, true, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running non-empty changeset")
 	tu.AssertEqual(t, "build run", stdout.String())
 }
@@ -85,7 +118,7 @@ func TestProject_Run_WithArgs(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build",
+	err = project.Run(workDir, "build", false, true,
 		template.Scope{
 			"Args": []string{"arg1", "arg2"},
 			"Flags": map[string]string{

--- a/pkg/task/script.go
+++ b/pkg/task/script.go
@@ -3,8 +3,9 @@ package task
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	corelog "log"
 	"os"
+	"strings"
 
 	"github.com/bilus/oya/pkg/template"
 	"github.com/magefile/mage/sh"
@@ -48,7 +49,22 @@ func (s Script) Exec(workDir string, values template.Scope, stdout, stderr io.Wr
 	if err != nil {
 		return err
 	}
-	log.SetOutput(ioutil.Discard) // BUG(bilus): Suppress logging from the library. This prevents using standard logger anywhere else.
-	_, err = sh.Exec(nil, stdout, stderr, s.Shell, scriptFile.Name())
+	corelog.SetOutput(ioutil.Discard) // BUG(bilus): Suppress logging from the library. This prevents using standard logger anywhere else.
+
+	_, err = sh.Exec(env(), stdout, stderr, s.Shell, scriptFile.Name())
 	return err
+}
+
+func env() map[string]string {
+	env := make(map[string]string)
+	for _, v := range os.Environ() {
+		parts := strings.SplitN(v, "=", 2)
+		switch len(parts) {
+		case 1:
+			env[parts[0]] = ""
+		case 2:
+			env[parts[0]] = parts[1]
+		}
+	}
+	return env
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -50,7 +50,10 @@ func Parse(source string) (Template, error) {
 }
 
 func RenderAll(templatePath, outputPath string, values Scope) error {
-	return filepath.Walk(templatePath, func(path string, info os.FileInfo, _ error) error {
+	return filepath.Walk(templatePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -46,7 +46,7 @@ func TestTemplate_Render_MissingVariables(t *testing.T) {
 	tu.AssertErr(t, err, "Expected template not to render")
 }
 
-func TestRenderAll(t *testing.T) {
+func TestRenderAll_Directory(t *testing.T) {
 	outputDir, err := ioutil.TempDir("", "oya")
 	tu.AssertNoErr(t, err, "Error creating temporary output dir")
 	defer os.RemoveAll(outputDir)
@@ -56,4 +56,15 @@ func TestRenderAll(t *testing.T) {
 
 	tu.AssertFileContains(t, filepath.Join(outputDir, "good.txt.kasia"), "bar\n")
 	tu.AssertFileContains(t, filepath.Join(outputDir, "subdir/nested.txt.kasia"), "bar\n")
+}
+
+func TestRenderAll_SingleFile(t *testing.T) {
+	outputDir, err := ioutil.TempDir("", "oya")
+	tu.AssertNoErr(t, err, "Error creating temporary output dir")
+	defer os.RemoveAll(outputDir)
+
+	err = template.RenderAll("./fixtures/good.txt.kasia", outputDir, template.Scope{"foo": "bar"})
+	tu.AssertNoErr(t, err, "Expected templates to render")
+
+	tu.AssertFileContains(t, filepath.Join(outputDir, "good.txt.kasia"), "bar\n")
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,6 +5,11 @@ import (
 )
 
 type Alias string
+
+func (a Alias) String() string {
+	return string(a)
+}
+
 type ImportPath string
 
 func (p ImportPath) Host() Host {


### PR DESCRIPTION
Here's what I did:

  1. Rename `--alias` => --scope 
  2. Add `--auto-scope` (using OYA_SCOPE) = in task you specify it to select the imported task's scope automatically.
  3. make `-f` optional ❗ It already was -- all I did is clarify .feature tests.
  4. arbitrarily nest `--``scope` e.g. `--scope foo.bar`
  5. `--output-dir` 

See .features for details.

Rationale: I generalized the alias-based scoping when rendering because it turned out to be useful when thinking about the k8s helm-like pack. It allows you to specify which environment you want to deploy to (`--scope staging`) if you want to keep values for all environments in a single Oyafile:

```
Values:
  staging:
    password: foo
  production:
    password: bar

deploy: |
  oya render --scope $Args[0] deploy.txt
```

deploy.txt
```
Deploying using $password
```

It also makes it easier to explain scoping for imported packs: instead of talking about aliases you simply say that an imported pack has its own value scope and is isolated from other packs. This turned out to work out similar to how it works in Helm.

UPDATE: --auto-scope is not turned on by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bilus/oya/51)
<!-- Reviewable:end -->
