### PR TITLE
Explicit recursion, changesets for `oya run` and `oya tasks`

### DIFF
--- a/cmd/internal/run.go
+++ b/cmd/internal/run.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bilus/oya/pkg/template"
 )
 
-func Run(workDir, taskName string, positionalArgs []string, flags map[string]string, stdout, stderr io.Writer) error {
+func Run(workDir, taskName string, recurse bool, positionalArgs []string, flags map[string]string, stdout, stderr io.Writer) error {
 	installDir, err := installDir()
 	if err != nil {
 		return err
@@ -30,13 +30,13 @@ func Run(workDir, taskName string, positionalArgs []string, flags map[string]str
 	tn := task.Name(taskName)
 
 	alias, _ := tn.Split()
-	oldScope, _ := lookupOyaScope()
+	oldOyaScope, _ := lookupOyaScope()
 	if err := setOyaScope(alias.String()); err != nil {
 		return err
 	}
-	defer setOyaScope(oldScope)
+	defer setOyaScope(oldOyaScope) // Mostly useful in tests, child processes naturally implement stacks.
 
-	return p.Run(workDir, tn, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
+	return p.Run(workDir, tn, recurse, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
 }
 
 func toScope(positionalArgs []string, flags map[string]string) template.Scope {

--- a/cmd/internal/run.go
+++ b/cmd/internal/run.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bilus/oya/pkg/template"
 )
 
-func Run(workDir, taskName string, recurse bool, positionalArgs []string, flags map[string]string, stdout, stderr io.Writer) error {
+func Run(workDir, taskName string, recurse, changeset bool, positionalArgs []string, flags map[string]string, stdout, stderr io.Writer) error {
 	installDir, err := installDir()
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func Run(workDir, taskName string, recurse bool, positionalArgs []string, flags 
 	}
 	defer setOyaScope(oldOyaScope) // Mostly useful in tests, child processes naturally implement stacks.
 
-	return p.Run(workDir, tn, recurse, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
+	return p.Run(workDir, tn, recurse, changeset, toScope(positionalArgs, flags).Merge(values), stdout, stderr)
 }
 
 func toScope(positionalArgs []string, flags map[string]string) template.Scope {

--- a/cmd/internal/tasks.go
+++ b/cmd/internal/tasks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bilus/oya/pkg/task"
 )
 
-func Tasks(workDir string, stdout, stderr io.Writer) error {
+func Tasks(workDir string, recurse, changeset bool, stdout, stderr io.Writer) error {
 
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
 
@@ -26,7 +26,7 @@ func Tasks(workDir string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	oyafiles, err := p.Changeset(workDir)
+	oyafiles, err := p.RunTargets(workDir, recurse, changeset)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -48,13 +48,18 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return internal.Run(cwd, taskName, recurse, positionalArgs, flags, cmd.OutOrStdout(), cmd.OutOrStderr())
+		changeset, err := cmd.Flags().GetBool("changeset")
+		if err != nil {
+			return err
+		}
+		return internal.Run(cwd, taskName, recurse, changeset, positionalArgs, flags, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().BoolP("recurse", "r", false, "Recursively process Oyafiles")
+	runCmd.Flags().BoolP("changeset", "c", false, "Use the Changeset: directives")
 }
 
 func parseArgs(args []string) ([]string, string, []string, map[string]string, error) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/bilus/oya/cmd/internal"
 	"github.com/bilus/oya/pkg/flags"
@@ -29,23 +30,50 @@ var runCmd = &cobra.Command{
 	Args:               cobra.ArbitraryArgs,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		taskName := args[0]
 		cwd, err := os.Getwd()
 		if err != nil {
 			return err
 		}
-		positionalArgs, flags, err := parseArgs(args)
+		cobraFlags, taskName, positionalArgs, flags, err := parseArgs(args)
 		if err != nil {
 			return err
 		}
-		return internal.Run(cwd, taskName, positionalArgs, flags, cmd.OutOrStdout(), cmd.OutOrStderr())
+		// BUG(bilus): Yack. This is what has to be done to support arbitrary flags passed to tasks.
+		cmd.DisableFlagParsing = false
+		defer func() { cmd.DisableFlagParsing = true }()
+		if err := cmd.ParseFlags(cobraFlags); err != nil {
+			return err
+		}
+		recurse, err := cmd.Flags().GetBool("recurse")
+		if err != nil {
+			return err
+		}
+		return internal.Run(cwd, taskName, recurse, positionalArgs, flags, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(runCmd)
+	runCmd.Flags().BoolP("recurse", "r", false, "Recursively process Oyafiles")
 }
 
-func parseArgs(args []string) ([]string, map[string]string, error) {
-	return flags.Parse(args[1:])
+func parseArgs(args []string) ([]string, string, []string, map[string]string, error) {
+	cobraFlags, rest := detectFlags(args)
+	taskName := rest[0]
+	posArgs, flags, err := flags.Parse(rest[1:])
+	return cobraFlags, taskName, posArgs, flags, err
+}
+
+// detectFlags processed args consisting of flags followed by positional arguments, splitting them.
+// For example this: ["--foo", "-b", "xxx", "--foo"] becomes: ["--foo", "-b"], ["xxx", "--foo"].
+func detectFlags(args []string) ([]string, []string) {
+	flags := make([]string, 0, len(args))
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+		} else {
+			return flags, args[i:]
+		}
+	}
+	return flags, nil
 }

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -36,11 +36,21 @@ var tasksCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return internal.Tasks(cwd, cmd.OutOrStdout(), cmd.OutOrStderr())
+		recurse, err := cmd.Flags().GetBool("recurse")
+		if err != nil {
+			return err
+		}
+		changeset, err := cmd.Flags().GetBool("changeset")
+		if err != nil {
+			return err
+		}
+		return internal.Tasks(cwd, recurse, changeset, cmd.OutOrStdout(), cmd.OutOrStderr())
 	},
 	Args: cobra.NoArgs,
 }
 
 func init() {
 	rootCmd.AddCommand(tasksCmd)
+	tasksCmd.Flags().BoolP("recurse", "r", false, "Recursively process Oyafiles")
+	tasksCmd.Flags().BoolP("changeset", "c", false, "Use the Changeset: directives")
 }

--- a/features/builtins.feature
+++ b/features/builtins.feature
@@ -92,7 +92,7 @@ Scenario: Access Oyafile base directory
     all: |
       echo $BasePath
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout text matching
   """
@@ -150,7 +150,7 @@ Scenario: Access Oyafile Project name in nested dir
     all: |
       echo $Project
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout text matching
   """

--- a/features/changeset.feature
+++ b/features/changeset.feature
@@ -1,0 +1,90 @@
+Feature: Changesets
+
+Background:
+   Given I'm in project dir
+
+Scenario: No changes
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo ""
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo ""
+    all: |
+      echo "Project1"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  """
+
+Scenario: Child marks itself as changed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo ""
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo "+."
+    all: |
+      echo "Root"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Root
+
+  """
+
+Scenario: Child marks parent as changed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo ""
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo "+../"
+    all: |
+      echo "Root"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Root
+
+  """
+
+Scenario: Parent marks child as changed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    Changeset: echo "+project1/"
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    Changeset: echo ""
+    all: |
+      echo "Project1"
+    """
+  When I run "oya run --changeset --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Project1
+
+  """

--- a/features/get.feature
+++ b/features/get.feature
@@ -46,7 +46,7 @@ Scenario: Get two versions of the same pack
       fixtures: github.com/tooploox/oya-fixtures
     """
   When I'm in the ./project1 dir
-  And I run "oya run fixtures.version"
+  And I run "oya run --recurse fixtures.version"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/ignore.feature
+++ b/features/ignore.feature
@@ -13,7 +13,7 @@ Scenario: Empty .oyaignore
     """
     all: echo "subdir"
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -34,7 +34,7 @@ Scenario: Ignore file
     """
     all: echo "subdir"
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -58,7 +58,7 @@ Scenario: Wildcard ignore
     """
     all: echo "subdir/foo"
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/imports.feature
+++ b/features/imports.feature
@@ -234,3 +234,30 @@ Scenario: Import tasks in a subdir Oyafile
   all
 
   """
+
+Scenario: Import tasks from a subdirectory
+  Given file ./Oyafile containing
+    """
+    Project: main
+    """
+  And file ./project1/Oyafile containing
+    """
+    Values:
+      foo: project1
+
+    echo: |
+      echo "project1"
+    """
+  And file ./project2/Oyafile containing
+    """
+    Import:
+      project1: /project1
+    """
+  And I'm in the ./project2 dir
+  When I run "oya run project1.echo"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  project1
+
+  """

--- a/features/imports.feature
+++ b/features/imports.feature
@@ -136,7 +136,7 @@ Scenario: Access current project values
       echo $p1.foo
       echo $foo
     """
-  When I run "oya run all"
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -227,7 +227,7 @@ Scenario: Import tasks in a subdir Oyafile
       echo "all"
     """
   And I'm in the ./subdir dir
-  When I run "oya run foo.all"
+  When I run "oya run --recurse foo.all"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/run.feature
+++ b/features/run.feature
@@ -87,92 +87,6 @@ Scenario: Nested Oyafiles can be processed recursively
   And file ./project1/Project1 exists
   And file ./project2/Project2 exists
 
-Scenario: No changes
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo ""
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo ""
-    all: |
-      echo "Project1"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  """
-
-Scenario: Child marks itself as changed
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo ""
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo "+."
-    all: |
-      echo "Root"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  Root
-
-  """
-
-Scenario: Child marks parent as changed
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo ""
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo "+../"
-    all: |
-      echo "Root"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  Root
-
-  """
-
-Scenario: Parent marks child as changed
-  Given file ./Oyafile containing
-    """
-    Project: project
-    Changeset: echo "+project1/"
-    all: |
-      echo "Root"
-    """
-  And file ./project1/Oyafile containing
-    """
-    Changeset: echo ""
-    all: |
-      echo "Project1"
-    """
-  When I run "oya run all"
-  Then the command succeeds
-  And the command outputs to stdout
-  """
-  Project1
-
-  """
-
 Scenario: No Oyafile
   Given file ./NotOyafile containing
     """
@@ -253,7 +167,7 @@ Scenario: Ignore errors in projects inside current project
 
   """
 
-Scenario: Running in subdir
+Scenario: Running recursively
   Given file ./Oyafile containing
     """
     Project: project
@@ -274,7 +188,39 @@ Scenario: Running in subdir
       echo "Project2"
     """
   And I'm in the ./project1 dir
-  When I run "oya run all"
+  When I run "oya run --recurse all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Project1
+
+  """
+  And file ././Root does not exist
+  And file ./Project1 exists
+  And file ./../project2/Project2 does not exist
+
+Scenario: Running recursively
+  Given file ./Oyafile containing
+    """
+    Project: project
+    all: |
+      touch Root
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    all: |
+      touch Project1
+      echo "Project1"
+    """
+  And file ./project2/Oyafile containing
+    """
+    all: |
+      touch Project2
+      echo "Project2"
+    """
+  And I'm in the ./project1 dir
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/run.feature
+++ b/features/run.feature
@@ -23,7 +23,7 @@ Scenario: Successfully run task
   """
   And file ./OK exists
 
-Scenario: Nested Oyafiles
+Scenario: Nested Oyafiles are not processed recursively by default
   Given file ./Oyafile containing
     """
     Project: project
@@ -44,6 +44,37 @@ Scenario: Nested Oyafiles
       echo "Project2"
     """
   When I run "oya run all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Root
+
+  """
+  And file ./Root exists
+  And file ./project1/Project1 does not exist
+  And file ./project2/Project2 does not exist
+
+Scenario: Nested Oyafiles can be processed recursively
+  Given file ./Oyafile containing
+    """
+    Project: project
+    all: |
+      touch Root
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    all: |
+      touch Project1
+      echo "Project1"
+    """
+  And file ./project2/Oyafile containing
+    """
+    all: |
+      touch Project2
+      echo "Project2"
+    """
+  When I run "oya run --recurse all"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/features/run.feature
+++ b/features/run.feature
@@ -230,3 +230,24 @@ Scenario: Running recursively
   And file ././Root does not exist
   And file ./Project1 exists
   And file ./../project2/Project2 does not exist
+
+Scenario: Running in a subdirectory
+  Given file ./Oyafile containing
+    """
+    Project: project
+    all: |
+      echo "Root"
+    """
+  And file ./project1/Oyafile containing
+    """
+    all: |
+      echo "Project1"
+    """
+  And I'm in the ./project1 dir
+  When I run "oya run all"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  Project1
+
+  """

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -36,7 +36,7 @@ Scenario: Show only user-defined
 
   """
 
-Scenario: Subdirectories
+Scenario: Subdirectories are not recursed by default
   Given file ./Oyafile containing
     """
     Project: project
@@ -49,6 +49,27 @@ Scenario: Subdirectories
       echo "Done"
     """
   When I run "oya tasks"
+  Then the command succeeds
+  And the command outputs to stdout
+  """
+  # in ./Oyafile
+  oya run build
+
+  """
+
+Scenario: Subdirectories can be recursed
+  Given file ./Oyafile containing
+    """
+    Project: project
+    build: |
+      echo "Done"
+    """
+  And file ./subdir1/Oyafile containing
+    """
+    build: |
+      echo "Done"
+    """
+  When I run "oya tasks --recurse"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -98,7 +119,7 @@ Scenario: Doc strings are properly aligned
     foo: |
       echo "Done"
     """
-  When I run "oya tasks"
+  When I run "oya tasks --recurse"
   Then the command succeeds
   And the command outputs to stdout
   """
@@ -131,7 +152,7 @@ Scenario: Parent dir tasks are not listed
       echo "Done"
     """
   And I'm in the ./subdir1 dir
-  When I run "oya tasks"
+  When I run "oya tasks --recurse"
   Then the command succeeds
   And the command outputs to stdout
   """

--- a/pkg/project/packs.go
+++ b/pkg/project/packs.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p *Project) Require(pack pack.Pack) error {
-	raw, err := p.rootRawOyafile()
+	raw, err := p.rawOyafileIn(p.RootDir)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (p *Project) Deps() (Deps, error) {
 		return p.dependencies, nil
 	}
 
-	o, err := p.rootOyafile()
+	o, err := p.oyafileIn(p.RootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -37,7 +37,7 @@ func Detect(workDir, installDir string) (*Project, error) {
 func (p *Project) Run(workDir string, taskName task.Name, recurse, useChangeset bool, scope template.Scope, stdout, stderr io.Writer) error {
 	log.Debugf("Task %q at %v", taskName, workDir)
 
-	targets, err := p.gatherRunTargets(workDir, recurse, useChangeset)
+	targets, err := p.RunTargets(workDir, recurse, useChangeset)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (p *Project) Run(workDir string, taskName task.Name, recurse, useChangeset 
 	return nil
 }
 
-func (p *Project) gatherRunTargets(workDir string, recurse, useChangeset bool) ([]*oyafile.Oyafile, error) {
+func (p *Project) RunTargets(workDir string, recurse, useChangeset bool) ([]*oyafile.Oyafile, error) {
 	if useChangeset {
 		changes, err := p.Changeset(workDir)
 		if err != nil {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -85,46 +85,45 @@ func (p *Project) RunTargets(workDir string, recurse, useChangeset bool) ([]*oya
 		}
 
 		if !recurse {
-			o, err := p.rootOyafile()
-			if err != nil {
-				return nil, err
-			}
-			return []*oyafile.Oyafile{o}, nil
+			return p.oneTargetIn(workDir)
 		} else {
 			return changes, nil
 		}
 	} else {
 		if !recurse {
-			o, err := p.rootOyafile()
-			if err != nil {
-				return nil, err
-			}
-			return []*oyafile.Oyafile{o}, nil
+			return p.oneTargetIn(workDir)
 		} else {
 			return p.List(workDir)
 		}
 	}
 }
 
-func (p *Project) rootOyafile() (*oyafile.Oyafile, error) {
-	o, found, err := oyafile.LoadFromDir(p.RootDir, p.RootDir)
+func (p *Project) oneTargetIn(dir string) ([]*oyafile.Oyafile, error) {
+	o, err := p.oyafileIn(dir)
+	if err != nil {
+		return nil, err
+	}
+	return []*oyafile.Oyafile{o}, nil
+}
+
+func (p *Project) oyafileIn(dir string) (*oyafile.Oyafile, error) {
+	o, found, err := oyafile.LoadFromDir(dir, p.RootDir)
 	if err != nil {
 		return nil, err
 	}
 	if !found {
-		return nil, ErrNoOyafile{Path: p.RootDir}
+		return nil, ErrNoOyafile{Path: dir}
 	}
-
 	return o, nil
 }
 
-func (p *Project) rootRawOyafile() (*raw.Oyafile, error) {
-	o, found, err := raw.LoadFromDir(p.RootDir, p.RootDir)
+func (p *Project) rawOyafileIn(dir string) (*raw.Oyafile, error) {
+	o, found, err := raw.LoadFromDir(dir, p.RootDir)
 	if err != nil {
 		return nil, err
 	}
 	if !found {
-		return nil, ErrNoOyafile{Path: p.RootDir}
+		return nil, ErrNoOyafile{Path: dir}
 	}
 
 	return o, nil

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -49,7 +49,15 @@ func TestProject_Run_NoTask(t *testing.T) {
 	installDir := "" // Unused
 	project, err := project.Detect(workDir, installDir)
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
-	err = project.Run(workDir, "noSuchTask", noScope, ioutil.Discard, ioutil.Discard)
+	err = project.Run(workDir, "noSuchTask", false, noScope, ioutil.Discard, ioutil.Discard)
+	tu.AssertErr(t, err, "Expected error when trying to run without matching task")
+}
+func TestProject_Run_NoTaskRecurse(t *testing.T) {
+	workDir := "./fixtures/project"
+	installDir := "" // Unused
+	project, err := project.Detect(workDir, installDir)
+	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
+	err = project.Run(workDir, "noSuchTask", true, noScope, ioutil.Discard, ioutil.Discard)
 	tu.AssertErr(t, err, "Expected error when trying to run without matching task")
 }
 
@@ -60,7 +68,20 @@ func TestProject_Run_NoChanges(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", noScope, stdout, stderr)
+	err = project.Run(workDir, "build", false, noScope, stdout, stderr)
+	tu.AssertNoErr(t, err, "Expected no error running with empty changeset")
+	tu.AssertEqual(t, 0, len(stdout.String()))
+	tu.AssertEqual(t, 0, len(stderr.String()))
+}
+
+func TestProject_Run_NoChangesRecurse(t *testing.T) {
+	workDir := "./fixtures/empty_changeset_project"
+	installDir := "" // Unused
+	project, err := project.Detect(workDir, installDir)
+	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err = project.Run(workDir, "build", true, noScope, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running with empty changeset")
 	tu.AssertEqual(t, 0, len(stdout.String()))
 	tu.AssertEqual(t, 0, len(stderr.String()))
@@ -73,7 +94,19 @@ func TestProject_Run_WithChanges(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
+	err = project.Run(workDir, "build", false, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
+	tu.AssertNoErr(t, err, "Expected no error running non-empty changeset")
+	tu.AssertEqual(t, "build run", stdout.String())
+}
+
+func TestProject_Run_WithChangesRecurse(t *testing.T) {
+	workDir := "./fixtures/project"
+	installDir := "" // Unused
+	project, err := project.Detect(workDir, installDir)
+	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err = project.Run(workDir, "build", true, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running non-empty changeset")
 	tu.AssertEqual(t, "build run", stdout.String())
 }
@@ -85,7 +118,7 @@ func TestProject_Run_WithArgs(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build",
+	err = project.Run(workDir, "build", false,
 		template.Scope{
 			"Args": []string{"arg1", "arg2"},
 			"Flags": map[string]string{

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -49,7 +49,7 @@ func TestProject_Run_NoTask(t *testing.T) {
 	installDir := "" // Unused
 	project, err := project.Detect(workDir, installDir)
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
-	err = project.Run(workDir, "noSuchTask", false, noScope, ioutil.Discard, ioutil.Discard)
+	err = project.Run(workDir, "noSuchTask", false, false, noScope, ioutil.Discard, ioutil.Discard)
 	tu.AssertErr(t, err, "Expected error when trying to run without matching task")
 }
 func TestProject_Run_NoTaskRecurse(t *testing.T) {
@@ -57,7 +57,7 @@ func TestProject_Run_NoTaskRecurse(t *testing.T) {
 	installDir := "" // Unused
 	project, err := project.Detect(workDir, installDir)
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
-	err = project.Run(workDir, "noSuchTask", true, noScope, ioutil.Discard, ioutil.Discard)
+	err = project.Run(workDir, "noSuchTask", true, false, noScope, ioutil.Discard, ioutil.Discard)
 	tu.AssertErr(t, err, "Expected error when trying to run without matching task")
 }
 
@@ -68,7 +68,7 @@ func TestProject_Run_NoChanges(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", false, noScope, stdout, stderr)
+	err = project.Run(workDir, "build", false, true, noScope, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running with empty changeset")
 	tu.AssertEqual(t, 0, len(stdout.String()))
 	tu.AssertEqual(t, 0, len(stderr.String()))
@@ -81,7 +81,7 @@ func TestProject_Run_NoChangesRecurse(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", true, noScope, stdout, stderr)
+	err = project.Run(workDir, "build", true, true, noScope, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running with empty changeset")
 	tu.AssertEqual(t, 0, len(stdout.String()))
 	tu.AssertEqual(t, 0, len(stderr.String()))
@@ -94,7 +94,7 @@ func TestProject_Run_WithChanges(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", false, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
+	err = project.Run(workDir, "build", false, true, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running non-empty changeset")
 	tu.AssertEqual(t, "build run", stdout.String())
 }
@@ -106,7 +106,7 @@ func TestProject_Run_WithChangesRecurse(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", true, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
+	err = project.Run(workDir, "build", true, true, template.Scope{"Args": noArgs, "Flags": noFlags}, stdout, stderr)
 	tu.AssertNoErr(t, err, "Expected no error running non-empty changeset")
 	tu.AssertEqual(t, "build run", stdout.String())
 }
@@ -118,7 +118,7 @@ func TestProject_Run_WithArgs(t *testing.T) {
 	tu.AssertNoErr(t, err, "Expected no error trying to detect Oya project in its root dir")
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = project.Run(workDir, "build", false,
+	err = project.Run(workDir, "build", false, true,
 		template.Scope{
 			"Args": []string{"arg1", "arg2"},
 			"Flags": map[string]string{

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -50,7 +50,10 @@ func Parse(source string) (Template, error) {
 }
 
 func RenderAll(templatePath, outputPath string, values Scope) error {
-	return filepath.Walk(templatePath, func(path string, info os.FileInfo, _ error) error {
+	return filepath.Walk(templatePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
`oya run`/`oya tasks`: not recurse by default, add `--recurse, -r` option 
    1. no options: just run/list tasks in the current directory
    2. `--recurse`: process recursively
    3. `--changeset`: use changeset
    4. can be combined

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bilus/oya/52)
<!-- Reviewable:end -->
